### PR TITLE
Colorize nicks on IRC.

### DIFF
--- a/skype2irc.py
+++ b/skype2irc.py
@@ -163,7 +163,8 @@ def get_nick_color(s):
     return colors[num]
 
 def get_nick_decorated(nick):
-    """Decorate nicks for better visibility in IRC (currently bold)"""
+    """Decorate nicks for better visibility in IRC (currently bold or
+    colors based on nick)"""
     if colors:
         return get_nick_color(nick) + nick + '\017'
     else:


### PR DESCRIPTION
I find it easier to follow a conversation if nicks are in different colors, so I added nick coloration.

This is a simple implementation whose color persists through restart, based on a hash function.
One could also write something more complicated to balance colors more evenly, but I don't think it's worse it.

PS: I modified my running script, then copy-pasted the edits to my machine that has git installed, so there might be a typo.
